### PR TITLE
Minor fix to align log file names

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ logging:
           kind: fixed_window
           base: 1
           count: 5
-          pattern: "dungeonfog.{}.log"
+          pattern: "ttod.{}.log"
       encoder:
         pattern: "{d} [{f}:{L}] {l} - {h({m})}{n}"
 

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ logging:
     # An appender named "requests" that writes to a file with a custom pattern encoder
     file:
       kind: rolling_file
-      path: ttod.log
+      path: tttod.log
       policy:
         kind: compound
         trigger:
@@ -18,7 +18,7 @@ logging:
           kind: fixed_window
           base: 1
           count: 5
-          pattern: "ttod.{}.log"
+          pattern: "tttod.{}.log"
       encoder:
         pattern: "{d} [{f}:{L}] {l} - {h({m})}{n}"
 


### PR DESCRIPTION
Probably for the best to use the repository name for the log files.
Using unexpected log names might obfuscate them from the user.